### PR TITLE
fix: remove skip ci from semantic-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       - run: echo //npm.pkg.github.com/:_authToken=$NUXT_PKG_TOKEN >> ~/.npmrc
         env:
           NUXT_PKG_TOKEN: ${{ secrets.NUXT_PKG_TOKEN }}
-      - run: yarn release --ci
+      - run: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.NUXT_PKG_TOKEN }}
 


### PR DESCRIPTION
fix: remove skip ci from semantic-release